### PR TITLE
Export DBus service

### DIFF
--- a/data/com.hack_computer.Libquest.service.in
+++ b/data/com.hack_computer.Libquest.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=com.hack_computer.Libquest
+Exec=@bindir@/com.hack_computer.Libquest

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,2 +1,17 @@
 install_subdir('quests', install_dir: pkgdatadir)
 
+session_bus_services_dir = get_option('session-bus-services-dir')
+if session_bus_services_dir == ''
+   session_bus_services_dir = dbus_dep.get_pkgconfig_variable('session_bus_services_dir')
+endif
+
+conf = configuration_data()
+conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+
+configure_file(
+    input: 'com.hack_computer.Libquest.service.in',
+    output: 'com.hack_computer.Libquest.service',
+    install: true,
+    install_dir: session_bus_services_dir,
+    configuration: conf
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,5 @@
 option('jasmine_junit_reports_dir', type: 'string',
     description: 'Where to put test reports')
+option('session-bus-services-dir',
+       description: 'the directory to install D-Bus services',
+       type: 'string')


### PR DESCRIPTION
This will make the service dbus activatable.

https://phabricator.endlessm.com/T30228

This is required to make it work with the clubhouse in katamari. I've copied the dbus service from the [game state service](https://github.com/endlessm/hack-game-state-service/blob/master/meson.build#L4-L19).