### PR TITLE
flatpak: set session-bus-services-dir to /app

### DIFF
--- a/com.hack_computer.Libquest.json.in
+++ b/com.hack_computer.Libquest.json.in
@@ -15,6 +15,9 @@
       "name": "libquest",
       "buildsystem": "meson",
       "run-tests": "@RUN_TESTS@",
+      "config-opts": [
+        "-Dsession-bus-services-dir=/app/share/dbus-1/services"
+      ],
       "sources": [
         {"type": "dir", "path": "."}
       ]


### PR DESCRIPTION
This option is needed to build in flatpak, without this it tries to install in `/usr` that's read only.